### PR TITLE
Add interface for selecting single or multiplayer and for selecting p…

### DIFF
--- a/Assets/entities/shared/Ball Spawner.prefab
+++ b/Assets/entities/shared/Ball Spawner.prefab
@@ -19,12 +19,9 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4653202098466440}
-  - component: {fileID: 114938126841040366}
-  - component: {fileID: 114416273132214324}
-  - component: {fileID: 114302669972501566}
   m_Layer: 0
   m_Name: Ball Spawner
-  m_TagString: Untagged
+  m_TagString: BallSpawner
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -35,65 +32,10 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1398745474243218}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.24, y: 0.46, z: 0}
+  m_LocalRotation: {x: -0, y: 0.7063106, z: -0, w: 0.70790213}
+  m_LocalPosition: {x: 0.002793863, y: 0.46000004, z: -1.2399968}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114302669972501566
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1398745474243218}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f17309ebfe412e4e81751878dd3f0ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114416273132214324
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1398745474243218}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 646fe4d8f8e2fb4409c3b0c3bd30b5b1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ballPrefab: {fileID: 1590068067264468, guid: 097876309fa797142a215e7e10edc0de, type: 2}
---- !u!114 &114938126841040366
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1398745474243218}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SceneId:
-    m_Value: 0
-  m_AssetId:
-    i0: 154
-    i1: 130
-    i2: 156
-    i3: 186
-    i4: 68
-    i5: 168
-    i6: 20
-    i7: 232
-    i8: 217
-    i9: 125
-    i10: 169
-    i11: 172
-    i12: 91
-    i13: 252
-    i14: 10
-    i15: 102
-  m_ServerOnly: 0
-  m_LocalPlayerAuthority: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 89.871, z: 0}

--- a/Assets/entities/shared/paddle_prefab.prefab
+++ b/Assets/entities/shared/paddle_prefab.prefab
@@ -28,6 +28,7 @@ GameObject:
   - component: {fileID: 136224915192230348}
   - component: {fileID: 114442914418636928}
   - component: {fileID: 114889014047957614}
+  - component: {fileID: 114926957746133038}
   m_Layer: 0
   m_Name: paddle_prefab
   m_TagString: Untagged
@@ -176,7 +177,7 @@ MonoBehaviour:
     i14: 254
     i15: 63
   m_ServerOnly: 0
-  m_LocalPlayerAuthority: 1
+  m_LocalPlayerAuthority: 0
 --- !u!114 &114889014047957614
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -186,6 +187,17 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: de954ce9e42c3f848bc2ba60cc5816b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114926957746133038
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1015282142749604}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2275ac37e67904bc79427cc4f5875617, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!136 &136224915192230348

--- a/Assets/scripts/LoadAssets.cs
+++ b/Assets/scripts/LoadAssets.cs
@@ -19,7 +19,10 @@ public class LoadAssets : MonoBehaviour {
 
     private string[] activeVariants;
 
-    private bool bundlesLoaded;
+	public bool bundlesLoaded;
+
+	public delegate void FinishedCallback(bool success);
+	public FinishedCallback OnFinished;
 
     void Awake()
     {
@@ -162,6 +165,9 @@ public class LoadAssets : MonoBehaviour {
             yield break;
 
         yield return StartCoroutine(request);
+
+		// Trigger callbacks once the scene has loaded
+		OnFinished(true);
 
         // Calculate and display the elapsed time.
         float elapsedTime = Time.realtimeSinceStartup - startTime;

--- a/Assets/scripts/entity/PaddleNetworking.cs
+++ b/Assets/scripts/entity/PaddleNetworking.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.Networking.NetworkSystem;
+
+/// <summary>
+/// Tracks which client is controlling the paddle
+/// </summary>
+public class PaddleNetworking : NetworkBehaviour {
+
+	// Message handle for the client id message
+	private short ID_MESSAGE = 1002;
+
+	// The id for an AI controlled paddle (-1 may be Local)
+	public static int PADDLE_AI = -2;
+
+	// The id of the client controllign the paddle, server side replicated on clients
+	[SyncVar]
+	private int paddleClientId;
+
+	// The index of the paddle on the table, server side replicated on clients
+	[SyncVar]
+	private int paddleIndex;
+
+	void OnStartClient () 
+	{
+		// The paddle is by default AI controlled
+		paddleClientId = PADDLE_AI;
+	}
+
+	void Start()
+	{
+		// The paddle is default AI, register the message callback
+		paddleClientId = PADDLE_AI;
+		NetworkServer.RegisterHandler(ID_MESSAGE, OnReceiveClientId);
+	}
+
+	void Update () 
+	{
+
+	}
+
+	// Is the paddle being controlled by an AI
+	public bool IsAIControlled()
+	{
+		return paddleClientId == PADDLE_AI;
+	}
+
+	// Returns the id of the client controlling the paddle
+	public int GetClientId()
+	{
+		return paddleClientId;
+	}
+
+	// Updates the id of the client for this paddle on the server
+	public void PossessPaddle()
+	{
+		// If this client is not already controlling the paddle
+		if (paddleClientId != NetworkManager.singleton.client.connection.connectionId)
+		{
+			// Send a message to the server with the client id
+			SendClientId(NetworkManager.singleton.client.connection.connectionId);
+		}
+	}
+
+	// Updates the this paddle to be AI controlled on the server
+	public void UnPossessPaddle()
+	{
+		// If this client controls the paddle
+		if (paddleClientId == NetworkManager.singleton.client.connection.connectionId)
+		{
+			// Send a message to the server with the AI 
+			SendClientId(PADDLE_AI);
+		}
+	}
+
+	// Set the index of this paddle on the table
+	public void SetPaddleIndex(int index)
+	{
+		paddleIndex = index;
+	}
+
+	// Get the index of this paddle on the table
+	public int GetPaddleIndex()
+	{
+		return paddleIndex;
+	}
+
+	// Send network message to set the client id on the server
+	void SendClientId(int clientId)
+	{
+		// The message contains the client id and the paddle index
+		StringMessage msg = new StringMessage(clientId.ToString() + "." + paddleIndex.ToString());
+		NetworkManager.singleton.client.connection.Send(ID_MESSAGE, msg);
+	}
+
+	// Callback for when a message is received
+	void OnReceiveClientId(NetworkMessage netMsg)
+	{
+		// Only handle the message as the server
+		if (NetworkServer.connections.Count > 0)
+		{
+			// Parse the message into the client id and paddle index
+			string msg = netMsg.ReadMessage<StringMessage>().value; 
+			string[] parts = msg.Split('.');
+			int clientId = int.Parse(parts[0]);
+			int index = int.Parse(parts[1]);
+
+			// Find the paddle of the given index
+			foreach (PaddleNetworking paddle in GameObject.FindObjectsOfType<PaddleNetworking>())
+			{
+				if (paddle.GetPaddleIndex() == index)
+				{
+					// Set the id to the given client id
+					paddle.SetClientId(clientId);
+				}
+			}
+		}
+	}
+
+	// Set the client id controlling this paddle
+	public void SetClientId(int clientId)
+	{
+		// If the paddle is being controlled by AI (does not override other client possession)
+		if (paddleClientId == PADDLE_AI && clientId != PADDLE_AI)
+		{
+			// Disable the AI for this paddle on the server
+			GetComponent<SimpleAI>().enabled = false;
+
+			// Find the client which is taking possession
+			foreach (NetworkConnection conn in NetworkServer.connections)
+			{
+				if (conn.connectionId == clientId)
+				{
+					// Assign that client control over the paddle
+					GetComponent<NetworkIdentity>().AssignClientAuthority(conn);
+					break;
+				}
+			}
+		}
+		// If the paddle is being controlled by a client
+		else if (paddleClientId != PADDLE_AI && clientId == PADDLE_AI)
+		{
+			// Find the client which has possession
+			foreach (NetworkConnection conn in NetworkServer.connections)
+			{
+				if (conn.connectionId == paddleClientId)
+				{
+					// Remove the client's control over the paddle
+					GetComponent<NetworkIdentity>().RemoveClientAuthority(conn);
+					break;
+				}
+			}
+
+			// Enabled the AI for this paddle on the server
+			GetComponent<SimpleAI>().enabled = true;
+		}
+
+		// Update the client id on the server (is replicated on clients)
+		paddleClientId = clientId;
+	}
+}

--- a/Assets/scripts/entity/PaddleNetworking.cs.meta
+++ b/Assets/scripts/entity/PaddleNetworking.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2275ac37e67904bc79427cc4f5875617
+timeCreated: 1492308760
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scripts/entity/SimpleAI.cs
+++ b/Assets/scripts/entity/SimpleAI.cs
@@ -32,7 +32,7 @@ public class SimpleAI : PaddleBase {
 
     private void FixedUpdate()
     {
-        if (!isLocalPlayer) return;
+		if (NetworkManager.singleton.isNetworkActive &&  NetworkServer.connections.Count == 0) return;
 
         if(trackedBall)
         {

--- a/Assets/scripts/ui/BasicMenu.cs
+++ b/Assets/scripts/ui/BasicMenu.cs
@@ -1,0 +1,316 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary>
+/// Hacky menu system until we have a proper UI
+/// </summary>
+
+public class BasicMenu : MonoBehaviour {
+
+	enum Menu {
+		/// <summary>
+		/// Initial menu for picking online/offline
+		/// </summary>
+		MainMenu,
+
+		/// <summary>
+		/// Search for online games/join a game
+		/// </summary>
+		Multiplayer,
+
+		/// <summary>
+		/// Select level and variant layout
+		/// </summary>
+		LevelSelect,
+
+		/// <summary>
+		/// Loading the selected level
+		/// </summary>
+		LoadingLevel,
+
+		/// <summary>
+		/// Setup the table
+		/// </summary>
+		SetupTable,
+
+		/// <summary>
+		/// Selecting which player(s) to control
+		/// </summary>
+		PaddleSelect,
+
+		Done,	// needed for OnGui timing
+	};
+
+	Menu currentMenu;
+	Menu nextMenu;
+
+	void Start()
+	{
+		currentMenu = Menu.MainMenu;
+		nextMenu = Menu.LevelSelect;
+	}
+
+	void OnGUI()
+	{
+		switch (currentMenu)
+		{
+		case Menu.MainMenu:
+			{
+				// GUI Padding
+				GUILayout.Space(100);
+				GUILayout.BeginHorizontal();
+				GUILayout.Space(20);
+				GUILayout.BeginVertical();
+
+				// Header
+				GUILayout.BeginHorizontal();
+				GUILayout.Label("Pick your multiplayer type:");
+				GUILayout.EndHorizontal();
+
+				// GUI Padding
+				GUILayout.Space(15);
+
+				// Get player choice
+				GUILayout.BeginHorizontal();
+				if (GUILayout.Toggle(nextMenu == Menu.Multiplayer, "") | GUILayout.Button("Online"))
+				{
+					nextMenu = Menu.Multiplayer;
+				}
+				if (GUILayout.Toggle(nextMenu == Menu.LevelSelect, "") | GUILayout.Button("Local"))
+				{
+					nextMenu = Menu.LevelSelect;
+				}
+				GUILayout.EndHorizontal();
+
+				// GUI Padding
+				GUILayout.Space(15);
+
+				// Proceed to next step
+				if (GUILayout.Button("Proceed"))
+				{
+					currentMenu = nextMenu;
+				}
+
+				// End GUI Padding
+				GUILayout.EndVertical();
+				GUILayout.EndHorizontal();
+			}
+			break;
+
+
+		case Menu.Multiplayer:
+			{
+				// Show the multiplayer menu
+				if (NetworkManager.singleton.GetComponent<NetworkManagerHUD>().enabled == false)
+				{
+					NetworkManager.singleton.GetComponent<NetworkManagerHUD>().enabled = true;
+				}
+
+				// GUI Padding
+				GUILayout.Space(200);
+				GUILayout.BeginHorizontal();
+				GUILayout.Space(15);
+				// Show the table select menu if the network is active
+				if (GUILayout.Button("Proceed"))
+				{
+					if (NetworkManager.singleton.isNetworkActive)
+					{
+						// Hide the networking HUD
+						NetworkManager.singleton.GetComponent<NetworkManagerHUD>().enabled = false;
+
+						currentMenu = Menu.LevelSelect;
+						nextMenu = Menu.LoadingLevel;
+					}
+				}
+
+				GUILayout.EndHorizontal();
+			}
+			break;
+
+
+		case Menu.LevelSelect:
+			{
+				// Enable the asset loader and let it load the level async
+				var assetLoader = GetComponent<LoadAssets>();
+				Debug.Assert(assetLoader != null, "Missing asset loader!");
+
+				assetLoader.enabled = true;
+
+				// We want to know when it's finished
+				assetLoader.OnFinished += FinishedLoading;
+
+				currentMenu = Menu.LoadingLevel;
+				nextMenu = Menu.SetupTable;
+			}
+			break;
+
+		case Menu.LoadingLevel:
+			// Just waiting for stuff to happen here
+			//DrawCentered();
+			//GUILayout.Label("Loading...");
+			//UndoCentered();
+
+			break;
+
+		case Menu.SetupTable:
+			{
+				// Add the ball spawner script to a spawner in the scene otherwise it will spawn inactive
+				GameObject[] spawners = GameObject.FindGameObjectsWithTag("BallSpawner");
+				Debug.Assert(spawners.Length > 0, "Need at least one spawner in the scene so we know where to put the ball");
+				GameObject spawner = spawners[Random.Range(0, spawners.Length-1)];
+				spawner.AddComponent<BallSpawner>().ballPrefab = NetworkManager.singleton.spawnPrefabs[1];// Don't like this at all...
+				spawner.AddComponent<ResetBallUI>();
+
+				// Fill the table with AIs if offline or the server
+				if (!NetworkManager.singleton.isNetworkActive || NetworkServer.connections.Count > 0)
+				{
+					int paddleIndex = 0;
+
+					foreach (Transform spawnPosition in NetworkManager.singleton.startPositions)
+					{
+						Transform paddlePos = spawnPosition;
+						GameObject paddle = GameObject.Instantiate(NetworkManager.singleton.playerPrefab, paddlePos);
+
+						// Spawn on the clients
+						if (NetworkManager.singleton.isNetworkActive)
+						{
+							NetworkServer.Spawn(paddle);
+							paddle.GetComponent<PaddleNetworking>().SetPaddleIndex(paddleIndex);
+						}
+
+						paddleIndex++;
+					}
+				}
+
+				currentMenu = Menu.PaddleSelect;
+				nextMenu = Menu.Done;
+			}
+			break;
+
+		case Menu.PaddleSelect:
+			{
+				GUILayout.BeginHorizontal();
+				// GUI Padding
+				GUILayout.Space(15);
+				GUILayout.BeginVertical();
+				// GUI Padding
+				GUILayout.Space(15);
+
+				// Header
+				GUILayout.BeginHorizontal();
+				GUILayout.Label("Select paddles to control:");
+				GUILayout.EndHorizontal();
+
+				// GUI Padding
+				GUILayout.Space(15);
+
+				// Get player choice
+				GUILayout.BeginHorizontal();
+				GUILayout.Label("Paddles: ");
+
+				SimpleAI[] bots = GameObject.FindObjectsOfType<SimpleAI>();
+				int paddleIndex = 1;	
+
+				// Show a toggle box for each paddle in the scene based on whether it is AI controlled
+				foreach (SimpleAI bot in bots)
+				{
+					// By default use the local state of the AI component
+					bool isBot = bot.enabled;
+
+					// When networking use the server state
+					if (NetworkManager.singleton.isNetworkActive)
+					{
+						isBot = bot.GetComponent<PaddleNetworking>().IsAIControlled();
+					}
+
+					// Select whether the paddle should be player controlled
+					GUILayout.Toggle(!isBot, "");
+
+					if (GUILayout.Button("" + paddleIndex.ToString()))
+					{
+						// If on the network update the server information
+						if (NetworkManager.singleton.isNetworkActive)
+						{
+							if (isBot)
+							{
+								bot.gameObject.GetComponent<PaddleNetworking>().PossessPaddle();
+								bot.gameObject.GetComponent<Player>().enabled = true;
+							}
+							else
+							{
+								bot.gameObject.GetComponent<PaddleNetworking>().UnPossessPaddle();
+								bot.gameObject.GetComponent<Player>().enabled = false;
+							}
+						}
+						else
+						{
+							// If local switch whether the paddle is player controlled
+							bot.gameObject.GetComponent<Player>().enabled = isBot;
+							bot.enabled = !isBot;
+						}
+					}
+
+					paddleIndex++;
+				}
+
+				GUILayout.EndHorizontal();
+
+				// GUI Padding
+				GUILayout.Space(30);
+
+				// Proceed to next step
+				if (GUILayout.Button("Proceed"))
+				{
+					// Disable us as we're done here
+					currentMenu = Menu.Done;
+					this.enabled = false;
+				}
+
+				// End GUI Padding
+				GUILayout.EndVertical();
+				GUILayout.EndHorizontal();
+			}
+			break;
+		}
+	}
+
+
+	/// <summary>
+	/// Called when the scene has finished loading in
+	/// </summary>
+	/// <param name="success"></param>
+	void FinishedLoading(bool success)
+	{
+		Debug.Assert(success, "Failed to load level");
+
+		currentMenu = nextMenu;
+		nextMenu = Menu.MainMenu;
+
+		// Remove this delegate
+		GetComponent<LoadAssets>().OnFinished -= FinishedLoading;
+
+		NetworkServer.SpawnObjects();
+	}
+
+
+	/// <summary>
+	/// Utility functions for drawing at the center of the screen
+	/// </summary>
+	/// <param name="text"></param>
+	void DrawCentered()
+	{
+		GUILayout.BeginArea(new Rect(0, 0, Screen.width, Screen.height));
+		GUILayout.FlexibleSpace();
+		GUILayout.BeginHorizontal();
+		GUILayout.FlexibleSpace();
+	}
+	void UndoCentered()
+	{
+		GUILayout.FlexibleSpace();
+		GUILayout.EndHorizontal();
+		GUILayout.FlexibleSpace();
+		GUILayout.EndArea();
+	}
+}

--- a/Assets/scripts/ui/BasicMenu.cs.meta
+++ b/Assets/scripts/ui/BasicMenu.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: da02a64dd33a346a8846e57bd5657097
+timeCreated: 1492308661
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scripts/utils/BallSpawner.cs
+++ b/Assets/scripts/utils/BallSpawner.cs
@@ -10,14 +10,18 @@ public class BallSpawner : NetworkBehaviour {
     private void Update()
     {
         // HACK: Ball wont respawn when re-hosting...
-        if (!isServer) return;
+		if (NetworkManager.singleton.isNetworkActive &&  NetworkServer.connections.Count == 0) return;
 
         var ball = GameObject.FindGameObjectWithTag("Ball");
         if(ball == null)
         {
             ball = (GameObject)Instantiate(ballPrefab, transform.position, transform.rotation);
             ball.GetComponent<Rigidbody>().velocity = ball.transform.forward * 5;
-            NetworkServer.Spawn(ball);
+            
+			if (NetworkManager.singleton.isNetworkActive)
+			{
+				NetworkServer.Spawn(ball);
+			}
         }
     }
 

--- a/Assets/tables/BaseTable.unity
+++ b/Assets/tables/BaseTable.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311992, g: 0.38074034, b: 0.35872713, a: 1}
+  m_IndirectSpecularColor: {r: 0.37305924, g: 0.38069162, b: 0.35868883, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -119,6 +119,7 @@ GameObject:
   - component: {fileID: 709551605}
   - component: {fileID: 709551604}
   - component: {fileID: 709551607}
+  - component: {fileID: 709551608}
   m_Layer: 0
   m_Name: Network Manager
   m_TagString: Untagged
@@ -132,7 +133,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 709551603}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 227461547, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
   m_Name: 
@@ -163,7 +164,7 @@ MonoBehaviour:
   m_LogLevel: 2
   m_PlayerPrefab: {fileID: 1015282142749604, guid: 2d31cd2f22c199d4ca0814827eacfe3f,
     type: 2}
-  m_AutoCreatePlayer: 1
+  m_AutoCreatePlayer: 0
   m_PlayerSpawnMethod: 1
   m_OfflineScene: 
   m_OnlineScene: 
@@ -244,12 +245,24 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 709551603}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ea2a7f435ebae1b4ca457d0431a85d4b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   sceneAssetBundle: tables-bundle
+  bundlesLoaded: 0
+--- !u!114 &709551608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 709551603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da02a64dd33a346a8846e57bd5657097, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1294986265
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Ball
+  - BallSpawner
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
…addle to control. Adds paddle networking component for tracking which client controls a paddle. Adds basic menu containing OnGui interface for selecting single player or multiplayer and the paddle. Some of this will need refactored perhaps into AssetSpawner for spawning the AI paddles. Adjusts network settings on some prefabs and changes ball spawner to not rely on networking. Also adds callback to asset loader to integrate with the rest of the menu. Some issues with paddles drifting and multiple local inputs is not setup.

Builds on @bobsayshilol 's changes for single player.