### PR TITLE
Fix reset ball ui for local and multiplayer

### DIFF
--- a/Assets/scripts/ui/ResetBallUI.cs
+++ b/Assets/scripts/ui/ResetBallUI.cs
@@ -3,26 +3,49 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
+using UnityEngine.Networking.NetworkSystem;
 
 public class ResetBallUI : NetworkBehaviour {
+
+	// Message handle for the client id message
+	private short RESPAWN_MESSAGE = 1003;
+
+	void OnServerStart()
+	{
+		NetworkServer.RegisterHandler(RESPAWN_MESSAGE, OnResetBallPosition);
+	}
 
     private void OnGUI()
     {
         GUILayout.BeginArea(new Rect(Screen.width - 150, 10, 140, 40));
         if (GUILayout.Button("Reset Ball Position"))
-        {
-            CmdResetBallPosition();
+		{
+			ResetBallPosition();
         }
         GUILayout.EndArea();
     }
 
-    [Command]
-    private void CmdResetBallPosition()
+    [Server]
+	private void OnResetBallPosition(NetworkMessage netMsg)
     {
-        var ball = GameObject.FindGameObjectWithTag("Ball");
-        if(ball != null)
-        {
-            ball.GetComponent<Ball>().ResetPosition();
-        }
+		ResetBallPosition();
     }
+
+	private void ResetBallPosition()
+	{
+		if (NetworkServer.connections.Count > 0 || !NetworkManager.singleton.isNetworkActive)
+		{
+			// If local or the server reset the ball position
+			var ball = GameObject.FindGameObjectWithTag("Ball");
+			if(ball != null)
+			{
+				ball.GetComponent<Ball>().ResetPosition();
+			}
+		}
+		else
+		{
+			// Send an empty message of type respawn message
+			NetworkManager.singleton.client.connection.Send(RESPAWN_MESSAGE, new EmptyMessage());
+		}
+	}
 }


### PR DESCRIPTION
Implements a simple message to the server if the ball reset ui is used on a client and bypasses the messaging if playing locally.