### PR TITLE
Add networking to the powers

### DIFF
--- a/Assets/scripts/entity/PaddleNetworking.cs
+++ b/Assets/scripts/entity/PaddleNetworking.cs
@@ -155,4 +155,36 @@ public class PaddleNetworking : NetworkBehaviour {
 		// Update the client id on the server (is replicated on clients)
 		paddleClientId = clientId;
 	}
+
+	[Command]
+	public void CmdSetPower(int power)
+	{
+		RpcSetPowerClient(power);
+	}
+
+	[Command]
+	public void CmdUsePower()
+	{
+		RpcUsePowerClient();
+	}
+
+	[ClientRpc]
+	public void RpcSetPowerClient(int power)
+	{
+		// Set the power of the paddle if it is controlled by another client and is not an AI
+		if (paddleClientId != NetworkManager.singleton.client.connection.connectionId && paddleClientId != PADDLE_AI)
+		{
+			GetComponent<PowerManager>().AssignPower(power);
+		}
+	}
+
+	[ClientRpc]
+	public void RpcUsePowerClient()
+	{
+		// Use the power of the paddle if it is controlled by another client and is not an AI
+		if (paddleClientId != NetworkManager.singleton.client.connection.connectionId && paddleClientId != PADDLE_AI)
+		{
+			GetComponent<PowerManager>().ActivatePower();
+		}
+	}
 }

--- a/Assets/scripts/entity/powers/PowerManager.cs
+++ b/Assets/scripts/entity/powers/PowerManager.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-
+using UnityEngine.Networking;
 
 public class PowerManager : MonoBehaviour {
 
@@ -69,24 +69,48 @@ public class PowerManager : MonoBehaviour {
         if(Input.GetKeyDown(KeyCode.Space))
         {
             currentPower.Activate();
-            //TODO
+
             //Tell network power has activated
+			if (NetworkManager.singleton.isNetworkActive)
+			{
+				GetComponent<PaddleNetworking>().CmdUsePower();
+			}
         }
         if (oldPower!=null) oldPower.Update();
         if (currentPower!=null) currentPower.Update();
 
 	}
 
-    void giveNewPower()
+	void giveNewPower()
     {
-        oldPower = currentPower;
+		oldPower = currentPower;
+
         float randFloat = Random.Range(1, (float)(powerTypes.POWER_COUNT));
         int randInt = Mathf.FloorToInt(randFloat);
         currentPower = powerMapping[(powerTypes)randInt];
         currentPower.Ready();
 
         Debug.Log("Power Granted: " + powerMapping[(powerTypes)randInt].ToString() + " to player " + ownerId);
-        //TODO
+        
         //Tell network which power this player has
+		if (NetworkManager.singleton.isNetworkActive)
+		{
+			GetComponent<PaddleNetworking>().CmdSetPower(randInt);
+		}
     }
+
+	// Called by the server to assign a non-player with a power
+	public void AssignPower(int power)
+	{
+		oldPower = currentPower;
+
+		currentPower = powerMapping[(powerTypes)power];
+		currentPower.Ready();
+	}
+
+	// Called by the server to activate a power
+	public void ActivatePower()
+	{
+		currentPower.Activate();
+	}
 }


### PR DESCRIPTION
Implements a simple Command/ClientRPC system for assigning powers to clients and activating powers on all clients. Currently powers are not deterministic and so each client will see a different power. I am also unsure if some powers affect the ball, if so they will need to be applied on the server somehow. I think ensuring that powers are deterministic is a must if we want them to be networked else every power will need a separate network implementation.

I tested it extensively but seeing as the input currently applies to all paddles there is a slim chance it does not work and was a result of input being received in the background or something similar. Hopefully closes #57.