### PR TITLE
Makes volume changes consistent across restart

### DIFF
--- a/Assets/MainMenu.unity
+++ b/Assets/MainMenu.unity
@@ -362,6 +362,7 @@ GameObject:
   - component: {fileID: 232932567}
   - component: {fileID: 232932569}
   - component: {fileID: 232932570}
+  - component: {fileID: 232932571}
   m_Layer: 0
   m_Name: ScriptHolder
   m_TagString: Untagged
@@ -422,6 +423,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hoverOver: {fileID: 8300000, guid: 25e744ae23cee4e45a90221135aabf1b, type: 3}
   onClick: {fileID: 8300000, guid: 9751cd2c4cf6743939b000877a143f95, type: 3}
+--- !u!114 &232932571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 232932566}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62955a68a953f481ca10d1e466d1cee4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  musicSlider: {fileID: 2000680199}
+  sfxSlider: {fileID: 370348685}
+  sfxSource: {fileID: 0}
+  musicSource: {fileID: 0}
+  kyle: {fileID: 1820077974}
+  lclhster: {fileID: 1843313304}
 --- !u!1 &255209988
 GameObject:
   m_ObjectHideFlags: 0
@@ -880,7 +898,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2062539471}
+      - m_Target: {fileID: 232932571}
         m_MethodName: ChangeSFXVolume
         m_Mode: 1
         m_Arguments:
@@ -971,12 +989,18 @@ Prefab:
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 82610879947610586, guid: ea331ca223fa449558937bb4ee734ca0,
+    - target: {fileID: 114137415635821844, guid: ea331ca223fa449558937bb4ee734ca0,
         type: 2}
-      propertyPath: spreadCustomCurve.m_RotationOrder
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
+      propertyPath: musicSlider
+      value: 
+      objectReference: {fileID: 2000680199}
+    - target: {fileID: 114137415635821844, guid: ea331ca223fa449558937bb4ee734ca0,
+        type: 2}
+      propertyPath: sfxSlider
+      value: 
+      objectReference: {fileID: 370348685}
+    m_RemovedComponents:
+    - {fileID: 114137415635821844, guid: ea331ca223fa449558937bb4ee734ca0, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: ea331ca223fa449558937bb4ee734ca0, type: 2}
   m_IsPrefabParent: 0
 --- !u!1 &374471761
@@ -4276,7 +4300,7 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2062539469}
+      - m_Target: {fileID: 232932571}
         m_MethodName: Kyle3wynn
         m_Mode: 1
         m_Arguments:
@@ -4369,7 +4393,7 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2062539469}
+      - m_Target: {fileID: 232932571}
         m_MethodName: Lclhoster
         m_Mode: 1
         m_Arguments:
@@ -4908,7 +4932,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2062539471}
+      - m_Target: {fileID: 232932571}
         m_MethodName: ChangeMusicVolume
         m_Mode: 1
         m_Arguments:
@@ -5245,42 +5269,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2062539466 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1300611100889412, guid: ea331ca223fa449558937bb4ee734ca0,
-    type: 2}
-  m_PrefabInternal: {fileID: 370583068}
---- !u!82 &2062539467 stripped
-AudioSource:
-  m_PrefabParentObject: {fileID: 82037660747357440, guid: ea331ca223fa449558937bb4ee734ca0,
-    type: 2}
-  m_PrefabInternal: {fileID: 370583068}
---- !u!82 &2062539468 stripped
-AudioSource:
-  m_PrefabParentObject: {fileID: 82610879947610586, guid: ea331ca223fa449558937bb4ee734ca0,
-    type: 2}
-  m_PrefabInternal: {fileID: 370583068}
---- !u!114 &2062539469 stripped
-MonoBehaviour:
-  m_PrefabParentObject: {fileID: 114472525645647976, guid: ea331ca223fa449558937bb4ee734ca0,
-    type: 2}
-  m_PrefabInternal: {fileID: 370583068}
-  m_Script: {fileID: 11500000, guid: ba934ac568fc24da98f198aca7c2d107, type: 3}
---- !u!114 &2062539471
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2062539466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 62955a68a953f481ca10d1e466d1cee4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  musicSlider: {fileID: 2000680199}
-  sfxSlider: {fileID: 370348685}
-  sfxSource: {fileID: 2062539468}
-  musicSource: {fileID: 2062539467}
 --- !u!1 &2079915584
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/audio/SoundManager.prefab
+++ b/Assets/Resources/audio/SoundManager.prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 114472525645647976}
   - component: {fileID: 82610879947610586}
   - component: {fileID: 82037660747357440}
+  - component: {fileID: 114137415635821844}
   m_Layer: 0
   m_Name: SoundManager
   m_TagString: Untagged
@@ -53,7 +54,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 67835f08c6500454787d52ec2638a7dc, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 1
+  m_Volume: 0.25
   m_Pitch: 1
   Loop: 1
   Mute: 0
@@ -133,7 +134,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.25
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -189,7 +190,7 @@ AudioSource:
       tangentMode: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
-    m_RotationOrder: 4
+    m_RotationOrder: 0
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
@@ -202,6 +203,21 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!114 &114137415635821844
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1300611100889412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62955a68a953f481ca10d1e466d1cee4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  musicSlider: {fileID: 0}
+  sfxSlider: {fileID: 0}
+  sfxSource: {fileID: 82610879947610586}
+  musicSource: {fileID: 82037660747357440}
 --- !u!114 &114472525645647976
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -217,3 +233,4 @@ MonoBehaviour:
   musicSource: {fileID: 82037660747357440}
   lowPitchRange: 0.95
   highPitchRange: 1.05
+  TrueForKyle3wynn: 0

--- a/Assets/scripts/SoundManager.cs
+++ b/Assets/scripts/SoundManager.cs
@@ -29,7 +29,7 @@ public class SoundManager : MonoBehaviour
 	public static SoundManager instance = null;		//Allows other scripts to call functions from SoundManager.				
 	public float lowPitchRange = .95f;				//The lowest a sound effect will be randomly pitched.
 	public float highPitchRange = 1.05f;			//The highest a sound effect will be randomly pitched.
-    public bool TrueForKyle3wynn;
+    public bool trueForKyle3Wynn;
 	
 	void Awake ()
 	{
@@ -46,19 +46,6 @@ public class SoundManager : MonoBehaviour
 		DontDestroyOnLoad (gameObject);
 	}
 
-    //I know there's probably a better way to do this but I'm sleepy :/ - sjm
-    public void Kyle3wynn()
-    {
-        TrueForKyle3wynn = true;
-    }
-
-    public void Lclhoster()
-    {
-        TrueForKyle3wynn = false;
-
-    }
-	
-	
 	//Used to play single sound clips.
 	public void PlaySingle(AudioClip clip)
 	{

--- a/Assets/scripts/entity/SFXBall.cs
+++ b/Assets/scripts/entity/SFXBall.cs
@@ -19,7 +19,7 @@ public class SFXBall : MonoBehaviour {
 
     void Start()
     {
-        TrueForKyle3wynn = SoundManager.instance.TrueForKyle3wynn;
+        TrueForKyle3wynn = SoundManager.instance.trueForKyle3Wynn;
     }
 
 

--- a/Assets/scripts/ui/UGUIButtons.cs
+++ b/Assets/scripts/ui/UGUIButtons.cs
@@ -7,19 +7,25 @@ public class UGUIButtons : MonoBehaviour {
     public GameObject optionsPanel;
     public GameObject creditsPanel;
 
-
+    void Awake()
+    {
+        
+    }
 
     public void PlayGameButton()
     {
         SceneManager.LoadScene("BaseTable");
     }
 
+    //This will open the panel if it's closed and close it if it's open
     public void OptionsButton()
     {
-        CloseAllPanels();
+
         if (optionsPanel.activeSelf == false)
         {
+            CloseAllPanels();
             optionsPanel.SetActive(true);
+
         }
         else if (optionsPanel.activeSelf == true)
         {
@@ -29,9 +35,9 @@ public class UGUIButtons : MonoBehaviour {
 
     public void CreditsButton()
     {
-        CloseAllPanels();
         if (creditsPanel.activeSelf == false)
         {
+            CloseAllPanels();
             creditsPanel.SetActive(true);
         }
         else if (creditsPanel.activeSelf == true)
@@ -42,7 +48,7 @@ public class UGUIButtons : MonoBehaviour {
 
     public void QuitButton()
     {
-        //this should open a menu confirming your selection
+        //this should probably open a menu confirming your selection
         Application.Quit();
     }
 

--- a/Assets/scripts/ui/VolumeControls.cs
+++ b/Assets/scripts/ui/VolumeControls.cs
@@ -8,14 +8,75 @@ public class VolumeControls : MonoBehaviour {
     public Slider sfxSlider;
     public AudioSource sfxSource;
     public AudioSource musicSource;
+    public Toggle kyle;
+    public Toggle lclhster;
+
+    /*Awake() get's called when the scene opens even if it's on a dontdestroyonload object
+     * But I'm not doing that atm
+     * void Awake()
+    {
+
+    }*/
+
+    void Start()
+    {
+        /*Playerprefs doesn't store bools.  I'm leaving this here because I'm a code hoarrder - sjm
+        if (PlayerPrefs.HasKey("trueForKyle3Wynn"))
+        {
+            SoundManager.instance.trueForKyle3Wynn =  PlayerPrefs.Set
+        }
+        */
+
+        //sets the toggles when the scene loads
+        if (SoundManager.instance.trueForKyle3Wynn == true)
+        {
+            kyle.isOn = true;
+            lclhster.isOn = false;
+        }
+        else
+        {
+            kyle.isOn = false;
+            lclhster.isOn = true;
+        }
+
+
+
+        sfxSource = SoundManager.instance.efxSource;
+        musicSource = SoundManager.instance.musicSource;
+        if (PlayerPrefs.HasKey("soundVolume"))
+        {
+            sfxSource.volume = PlayerPrefs.GetFloat("soundVolume");
+            musicSource.volume = PlayerPrefs.GetFloat("musicVolume");
+        }
+
+        musicSlider.value = musicSource.volume;
+        sfxSlider.value = sfxSource.volume;
+    }
 
     public void ChangeMusicVolume()
     {
         musicSource.volume = musicSlider.value;
+        PlayerPrefs.SetFloat("musicVolume", musicSlider.value);
     }
 
     public void ChangeSFXVolume()
     {
         sfxSource.volume = sfxSlider.value;
+        PlayerPrefs.SetFloat("soundVolume", sfxSlider.value);
+
     }
+
+    //I know there's probably a better way to do this but I'm sleepy :/ - sjm
+    public void Kyle3wynn()
+    {
+        SoundManager.instance.trueForKyle3Wynn = true;
+
+    }
+
+    public void Lclhoster()
+    {
+        SoundManager.instance.trueForKyle3Wynn = false;
+
+    }
+
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -18,6 +18,7 @@ TagManager:
   - PowerUp
   - Flipper
   - TableNetworking
+  - FindMe
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
, and allows you to change volume and paddle sfx after leaving the menu.

paddle sfx settings are not saved on close, because playerprefs doesn't handle bools.  Maybe fix later. low priority.