### PR TITLE
Add debug log for latency on server

### DIFF
--- a/Assets/scripts/utils/TableNetworking.cs
+++ b/Assets/scripts/utils/TableNetworking.cs
@@ -14,12 +14,29 @@ public class TableNetworking : NetworkBehaviour
 	[SyncVar]
 	public bool selected;
 
+	public float logPingFrequency = 5.0f;
+
 	[ServerCallback]
 	void Start () 
 	{
 		selected = false;
 		table = "";
 		variant = "";
+
+		InvokeRepeating("LogPing", 0.0f, logPingFrequency);
+	}
+
+	void OnClientConnect(NetworkConnection conn)
+	{
+		InvokeRepeating("LogPing", 0.0f, logPingFrequency);
+	}
+
+	void LogPing()
+	{
+		foreach (NetworkClient conn in NetworkClient.allClients)
+		{
+			Debug.Log("Ping for connection " + conn.connection.address.ToString() + ": " + conn.GetRTT().ToString() + " (ms)");
+		}
 	}
 
 	public string GetTable()


### PR DESCRIPTION
As per fragmental's request simply outputs the ping of each client from the server. Currently outputs the ping every 5 seconds but can be adjusted on the Table Networking Prefab.