### PR TITLE
Networked obstacles

### DIFF
--- a/Assets/entities/shared/tableNetworking_prefab.prefab
+++ b/Assets/entities/shared/tableNetworking_prefab.prefab
@@ -21,6 +21,7 @@ GameObject:
   - component: {fileID: 4269623849355802}
   - component: {fileID: 114303799797387028}
   - component: {fileID: 114981176073580158}
+  - component: {fileID: 114668158023092524}
   m_Layer: 0
   m_Name: tableNetworking_prefab
   m_TagString: TableNetworking
@@ -55,24 +56,35 @@ MonoBehaviour:
   m_SceneId:
     m_Value: 0
   m_AssetId:
-    i0: 0
-    i1: 0
-    i2: 0
-    i3: 0
-    i4: 0
-    i5: 0
-    i6: 0
-    i7: 0
-    i8: 0
-    i9: 0
-    i10: 0
-    i11: 0
-    i12: 0
-    i13: 0
-    i14: 0
-    i15: 0
+    i0: 184
+    i1: 255
+    i2: 32
+    i3: 26
+    i4: 13
+    i5: 37
+    i6: 100
+    i7: 106
+    i8: 56
+    i9: 84
+    i10: 103
+    i11: 100
+    i12: 74
+    i13: 249
+    i14: 93
+    i15: 240
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
+--- !u!114 &114668158023092524
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1746585640701714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e9f42e9e6a1a4a649b98ca51402abcd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114981176073580158
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -87,3 +99,4 @@ MonoBehaviour:
   variant: 
   table: 
   selected: 0
+  logPingFrequency: 5

--- a/Assets/scripts/entity/FlipperController.cs
+++ b/Assets/scripts/entity/FlipperController.cs
@@ -11,26 +11,39 @@ public class FlipperController : MonoBehaviour
     public string inputButtonName = "LeftFlipper";
     private HingeJoint paddleHingeJoint;
 
+	JointSpring spring;
+
     private JointLimits limits;
  
     void  Awake (){
         GetComponent<HingeJoint>().useSpring = true;
+
+		// Callback to the activate/deactivate methods from server
+		GetComponent<ObstacleNetworking>().ActivateFromServer += ActivateFlipper;
+		GetComponent<ObstacleNetworking>().DeactivateFromServer += DeactivateFlipper;
+
+		spring = new JointSpring();
     }
 
    
     void  Update (){
-        JointSpring spring = new JointSpring();
 
         spring.spring = flipperStrength;
         spring.damper = flipperDamper;
 
-        if (Input.GetButton(inputButtonName))
+		if (Input.GetButtonDown(inputButtonName))
         {
-            spring.targetPosition = pressedPosition;
+			ActivateFlipper();
+
+			// Activate the flipper on all clients
+			GetComponent<ObstacleNetworking>().ActivateOnServer();
         }
-        else
+		else if (Input.GetButtonUp(inputButtonName))
         {
-            spring.targetPosition = restPosition;
+			DeactivateFlipper();
+
+			// Deactivate the flipper on all clients
+			GetComponent<ObstacleNetworking>().DeactivateOnServer();
         }
 
         GetComponent<HingeJoint>().spring = spring;
@@ -40,6 +53,16 @@ public class FlipperController : MonoBehaviour
         limits.max = pressedPosition;
         GetComponent<HingeJoint>().limits = limits;
     }
+
+	void ActivateFlipper()
+	{
+		spring.targetPosition = pressedPosition;
+	}
+
+	void DeactivateFlipper()
+	{
+		spring.targetPosition = restPosition;
+	}
 
 
 }

--- a/Assets/scripts/entity/ObstacleManager.cs
+++ b/Assets/scripts/entity/ObstacleManager.cs
@@ -9,7 +9,7 @@ public class ObstacleManager : NetworkBehaviour
 	private short ACTIVATE_MESSAGE = 1100;
 	private short DEACTIVATE_MESSAGE = 1101;
 
-	ObstacleNetworking[] obstacles;
+	public ObstacleNetworking[] obstacles;
 
 	[ServerCallback]
 	void Start () 

--- a/Assets/scripts/entity/ObstacleManager.cs
+++ b/Assets/scripts/entity/ObstacleManager.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.Networking.NetworkSystem;
+
+public class ObstacleManager : NetworkBehaviour 
+{
+	private short ACTIVATE_MESSAGE = 1100;
+	private short DEACTIVATE_MESSAGE = 1101;
+
+	ObstacleNetworking[] obstacles;
+
+	[ServerCallback]
+	void Start () 
+	{
+		// Register the message handlers on the server
+		NetworkServer.RegisterHandler(ACTIVATE_MESSAGE, OnReceiveActivateMessage);
+		NetworkServer.RegisterHandler(DEACTIVATE_MESSAGE, OnReceiveDeactivateMessage);
+	}
+
+	void Update () 
+	{
+		// Fill the obstacle list once the table is spawned
+		if (obstacles.Length == 0 && Object.FindObjectOfType<ObstacleNetworking>() != null)
+		{
+			obstacles = Object.FindObjectsOfType<ObstacleNetworking>();
+		}
+	}
+
+	// Activate the obstacle on the server
+	public void ActivateObstacle(ObstacleNetworking obstacle)
+	{
+		IntegerMessage msg = new IntegerMessage(GetObstacleIndex(obstacle));
+		NetworkManager.singleton.client.connection.Send(ACTIVATE_MESSAGE, msg);
+	}
+
+	// Deactivate the obstacle on the server
+	public void DeactivateObstacle(ObstacleNetworking obstacle)
+	{
+		IntegerMessage msg = new IntegerMessage(GetObstacleIndex(obstacle));
+		NetworkManager.singleton.client.connection.Send(DEACTIVATE_MESSAGE, msg);
+	}
+
+	// Callback for when an activate message is received
+	[Server]
+	void OnReceiveActivateMessage(NetworkMessage netMsg)
+	{
+		// Retrieve the obstacle index
+		int obstacleIndex = netMsg.ReadMessage<IntegerMessage>().value;
+
+		RpcActivateObstacle(obstacleIndex);
+	}
+
+	// Callback for when a deactivate message is received
+	[Server]
+	void OnReceiveDeactivateMessage(NetworkMessage netMsg)
+	{
+		// Retrieve the obstacle index
+		int obstacleIndex = netMsg.ReadMessage<IntegerMessage>().value;
+
+		RpcDeactivateObstacle(obstacleIndex);
+	}
+
+	// Activate the obstacle on all clients
+	[ClientRpc]
+	public void RpcActivateObstacle(int obstacleIndex)
+	{
+		ObstacleNetworking obstacle = obstacles[obstacleIndex];
+
+		if (obstacle != null)
+		{
+			obstacle.ActivateFromServer();
+		}
+	}
+
+	// Deactivate the obstacle on all clients
+	[ClientRpc]
+	public void RpcDeactivateObstacle(int obstacleIndex)
+	{
+		ObstacleNetworking obstacle = obstacles[obstacleIndex];
+
+		if (obstacle != null)
+		{
+			obstacle.DeactivateFromServer();
+		}
+	}
+
+	// Find the index of the obstacle
+	public int GetObstacleIndex(ObstacleNetworking obstacle)
+	{
+		int obstacleIndex = 0;
+
+		foreach (ObstacleNetworking o in obstacles)
+		{
+			if (obstacle.gameObject == o.gameObject)
+			{
+				return obstacleIndex;
+			}
+
+			obstacleIndex++;
+		}
+
+		return -1;
+	}
+}

--- a/Assets/scripts/entity/ObstacleManager.cs.meta
+++ b/Assets/scripts/entity/ObstacleManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5e9f42e9e6a1a4a649b98ca51402abcd
+timeCreated: 1493049295
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scripts/entity/ObstacleNetworking.cs
+++ b/Assets/scripts/entity/ObstacleNetworking.cs
@@ -28,6 +28,8 @@ public class ObstacleNetworking : MonoBehaviour
 		if (NetworkManager.singleton.isNetworkActive)
 		{
 			obstacleManager.ActivateObstacle(this);
+
+			Debug.Log("activate on server");
 		}
 	}
 
@@ -37,6 +39,8 @@ public class ObstacleNetworking : MonoBehaviour
 		if (NetworkManager.singleton.isNetworkActive)
 		{
 			obstacleManager.DeactivateObstacle(this);
+
+			Debug.Log("deactivate on server");
 		}
 	}
 }

--- a/Assets/scripts/entity/ObstacleNetworking.cs
+++ b/Assets/scripts/entity/ObstacleNetworking.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class ObstacleNetworking : MonoBehaviour 
+{
+	ObstacleManager obstacleManager;
+
+	public delegate void ActivateCallback();
+	public ActivateCallback ActivateFromServer;
+
+	public delegate void DeactivateCallback();
+	public ActivateCallback DeactivateFromServer;
+
+	void Update () 
+	{
+		// Get the obstacle manager
+		if (obstacleManager == null)
+		{
+			obstacleManager = Object.FindObjectOfType<ObstacleManager>();
+		}
+	}
+
+	// Activate on the server and other clients
+	public void ActivateOnServer()
+	{
+		if (NetworkManager.singleton.isNetworkActive)
+		{
+			obstacleManager.ActivateObstacle(this);
+		}
+	}
+
+	// Deactivate on the server and other clients
+	public void DeactivateOnServer()
+	{
+		if (NetworkManager.singleton.isNetworkActive)
+		{
+			obstacleManager.DeactivateObstacle(this);
+		}
+	}
+}

--- a/Assets/scripts/entity/ObstacleNetworking.cs.meta
+++ b/Assets/scripts/entity/ObstacleNetworking.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 33429fe7e83564085a2effb72c0b0721
+timeCreated: 1493049616
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/tables/Table02.unity
+++ b/Assets/tables/Table02.unity
@@ -405,6 +405,17 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &109119902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 109119898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33429fe7e83564085a2effb72c0b0721, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &321258562
 GameObject:
   m_ObjectHideFlags: 0
@@ -1103,6 +1114,17 @@ MonoBehaviour:
   flipperStrength: 2000
   flipperDamper: 5
   inputButtonName: RightFlipper
+--- !u!114 &847371453
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 847371449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33429fe7e83564085a2effb72c0b0721, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &879866962
 Prefab:
   m_ObjectHideFlags: 0
@@ -1912,6 +1934,17 @@ MonoBehaviour:
   flipperStrength: 2000
   flipperDamper: 5
   inputButtonName: LeftFlipper
+--- !u!114 &1515719041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1515719037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33429fe7e83564085a2effb72c0b0721, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1568810183
 Prefab:
   m_ObjectHideFlags: 0
@@ -2518,6 +2551,17 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &1862793036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1862793032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33429fe7e83564085a2effb72c0b0721, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1888694072
 Prefab:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Adds a system for easily networking obstacles without registering every prefab. The flippers are implemented in this PR and can be referenced to implement other obstacles on the network. The implementation requires the obstacle to have the ObstacleNetworking component which does not have any parameters. Then when you want to activate the obstacle on the network simply call ActivateOnServer in the ObstacleNetworking component, or DeactivateOnServer to deactivate. In order to have the activation affect the other clients you must delegate some activate function to the ActivateFromServer method in ObstacleNetworking component as seen in the FlipperController script. Ensure that the activate method you implement does not call ActivateOnServer or you will create an endless loop. This PR also adds the obstacle Manager which is what communicates over the network and is attached to the table networking  #prefab.

Should resolve #65 in regards to flippers and any new obstacles should be very easy to network now. Tested on a single machine with two builds using ctrl and alt for the flippers.