### PR TITLE
Add credits and about panels to main menu

### DIFF
--- a/Assets/MainMenu.unity
+++ b/Assets/MainMenu.unity
@@ -383,6 +383,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   optionsPanel: {fileID: 1950911882}
   creditsPanel: {fileID: 863856749}
+  aboutPanel: {fileID: 1490119337}
 --- !u!4 &232932568
 Transform:
   m_ObjectHideFlags: 0
@@ -1204,11 +1205,11 @@ RectTransform:
   m_Children:
   - {fileID: 352368288}
   m_Father: {fileID: 1927025131}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -75.5}
+  m_AnchoredPosition: {x: 0, y: -111.5}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &531672204
@@ -1922,6 +1923,90 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!1 &774464914
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 774464915}
+  - component: {fileID: 774464918}
+  - component: {fileID: 774464917}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &774464915
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 774464914}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1490119338}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 10, y: 0.00015258999}
+  m_SizeDelta: {x: 550, y: 459.99}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &774464917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 774464914}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 78
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: 'Pongball has been developed as part of a series of community-run activities
+    during Double Fine''s Amnesia Fortnight 2017.
+
+
+    If you''d like to contribute, you can find Pongball''s source code on GitHub at
+    https://github.com/Double-Fine-Game-Club/pongball or you can join the discussion
+    at https://forums.doublefine.com/
+
+
+    TODO: Replace above with buttons to launch GitHub repo and forums in a browser
+    ^_^'
+--- !u!222 &774464918
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 774464914}
 --- !u!1 &779190673
 GameObject:
   m_ObjectHideFlags: 0
@@ -2168,7 +2253,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.00015258999}
+  m_AnchoredPosition: {x: -0.000030517578, y: 0.00016784668}
   m_SizeDelta: {x: 578, y: 459.99}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &848517075
@@ -2254,7 +2339,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.29339853, y: 0.000010863544}
   m_AnchorMax: {x: 1, y: 0.999988}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.000045776367, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &863856751
@@ -3059,6 +3144,80 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1221046047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1221046048}
+  - component: {fileID: 1221046050}
+  - component: {fileID: 1221046049}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1221046048
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1221046047}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1634854569}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1221046049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1221046047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 16
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: About
+--- !u!222 &1221046050
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1221046047}
 --- !u!1 &1295531644
 GameObject:
   m_ObjectHideFlags: 0
@@ -3338,6 +3497,75 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
+--- !u!1 &1490119337
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1490119338}
+  - component: {fileID: 1490119340}
+  - component: {fileID: 1490119339}
+  m_Layer: 5
+  m_Name: AboutPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1490119338
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1490119337}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 774464915}
+  m_Father: {fileID: 1573814346}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.29339853, y: 0.000010863544}
+  m_AnchorMax: {x: 1, y: 0.999988}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1490119339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1490119337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1490119340
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1490119337}
 --- !u!1 &1503194413
 GameObject:
   m_ObjectHideFlags: 0
@@ -3545,6 +3773,7 @@ RectTransform:
   - {fileID: 438744441}
   - {fileID: 863856750}
   - {fileID: 1302258508}
+  - {fileID: 1490119338}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3835,6 +4064,176 @@ MonoBehaviour:
       m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
         Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   delegates: []
+--- !u!1 &1634854568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1634854569}
+  - component: {fileID: 1634854573}
+  - component: {fileID: 1634854572}
+  - component: {fileID: 1634854571}
+  - component: {fileID: 1634854570}
+  m_Layer: 5
+  m_Name: AboutButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1634854569
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1634854568}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0000008, y: 1.0000017, z: 1.0000017}
+  m_Children:
+  - {fileID: 1221046048}
+  m_Father: {fileID: 1927025131}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -75.5}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1634854570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1634854568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1862395651, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 232932570}
+          m_MethodName: HoverOverSFX
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  - eventID: 4
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 232932570}
+          m_MethodName: OnClickSFX
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
+        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  delegates: []
+--- !u!114 &1634854571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1634854568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.45882356, g: 0.5019608, b: 0.7137255, a: 0}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1634854572}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 232932567}
+        m_MethodName: AboutButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &1634854572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1634854568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.49803925, g: 0.5058824, b: 0.59607846, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1634854573
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1634854568}
 --- !u!1 &1710204728
 GameObject:
   m_ObjectHideFlags: 0
@@ -4680,6 +5079,7 @@ RectTransform:
   - {fileID: 1787676339}
   - {fileID: 1625753106}
   - {fileID: 2030729643}
+  - {fileID: 1634854569}
   - {fileID: 531672203}
   m_Father: {fileID: 1573814346}
   m_RootOrder: 0

--- a/Assets/MainMenu.unity
+++ b/Assets/MainMenu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -2145,6 +2145,7 @@ GameObject:
   - component: {fileID: 848517074}
   - component: {fileID: 848517076}
   - component: {fileID: 848517075}
+  - component: {fileID: 848517077}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -2182,7 +2183,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2193,14 +2194,14 @@ MonoBehaviour:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 14
     m_FontStyle: 0
-    m_BestFit: 1
+    m_BestFit: 0
     m_MinSize: 10
     m_MaxSize: 78
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: Credits Go Here
 --- !u!222 &848517076
@@ -2209,6 +2210,17 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 848517073}
+--- !u!114 &848517077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 848517073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57bd2916956de439aa6e1fca4dc82e2c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &863856749
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/credits/credits-assets-git.txt
+++ b/Assets/Resources/credits/credits-assets-git.txt
@@ -1,5 +1,7 @@
 Cheese
 Cheeseness
+kednar
 Kieran Gunn
 Kjell Iwarson
 Kyle Wynn
+reidhcooper

--- a/Assets/Resources/credits/credits-extra.txt
+++ b/Assets/Resources/credits/credits-extra.txt
@@ -1,4 +1,3 @@
 Cheeseness @ValiantCheese
 ehne @possiblyanidiot
 lclhstr
-rhcooper

--- a/Assets/Resources/credits/credits-git.txt
+++ b/Assets/Resources/credits/credits-git.txt
@@ -1,7 +1,9 @@
 bobsayshilol
 Cheese
 Cheeseness
-ehne
+fierydrake
 James Wood
 Kjell Iwarson
+Michael McKenzie
 Stewart Martin
+VideogameScrapbook

--- a/Assets/scripts/ui/CreditsParser.cs
+++ b/Assets/scripts/ui/CreditsParser.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using System.Linq;
+using UnityEngine.UI;
+
+public class CreditsParser : MonoBehaviour {
+
+	private float posInitial;
+	private float posMax;
+	private int scrollSpeed = 20;
+
+	// Use this for initialization
+	void Start ()
+	{
+		Text textElement = GetComponent<Text>();
+		textElement.text = "Pongball has been made by the following community contributors:\n\n" + GetCreditsNames() + "\n\n\n"
+						+ "Pongball makes use of the following third party libraries/code:\n\n";
+						//TODO: Add details/licences of third party code
+		posInitial = - textElement.preferredHeight / 2;
+		posMax = Screen.height + textElement.preferredHeight / 2;
+		var t = transform.position;
+		t.y = posInitial;
+		transform.position = t;
+	}
+
+	// Update is called once per frame
+	void Update()
+	{
+		var t = transform.position;
+		if (t.y >= posMax)
+		{
+			t.y = posInitial;
+		}
+		else
+		{
+			t.y += scrollSpeed * Time.deltaTime;
+		}
+		transform.position = t;
+	}
+
+	string GetCreditsNames()
+	{
+		//Load the names from the main repo's git contributors and split it into a list based on newlines
+		TextAsset ta = Resources.Load<TextAsset>("credits/credits-git");
+		List<string> namesList = ta.text.Split("\n"[0]).ToList();
+
+		//Load the names from the assets repo's git contributors and split it into a list based on newlines
+		ta = Resources.Load<TextAsset>("credits/credits-assets-git");
+		var assetsNames = ta.text.Split("\n"[0]);
+
+		//Loop through and any names in the assets repo list that aren't already present
+		foreach (string s in assetsNames)
+		{
+			if (!namesList.Contains(s))
+			{
+				namesList.Add(s);
+			}
+		}
+
+
+		//Load the names/details from the credits-extra file and split it into a list based on newlines
+		ta = Resources.Load<TextAsset>("credits/credits-extra");
+		List<string> extra = ta.text.Split("\n"[0]).ToList();
+
+		//Loop throught and find lines that aren't already present
+		foreach (string s in extra)
+		{
+			if (!namesList.Contains(s))
+			{
+				//Loop through looking for matches in namesList and update that entry if we find one
+				int i = s.Length - 1;
+				while (i > 0)
+				{
+					string tempString = s.Substring(0, i);
+					if (namesList.Contains(tempString))
+					{
+						namesList[namesList.IndexOf(tempString)] = s;
+						break;
+					}
+					else
+					{
+						i = s.LastIndexOf(" "[0], i-1);
+					}
+				}
+
+				//If we couldn't find a match, the name is new, so add it
+				if (i < 0)
+				{
+					namesList.Add(s);
+				}
+			}
+		}
+
+		namesList.Sort();
+		while (namesList.Contains(""))
+		{
+			namesList.Remove("");
+		}
+		while (namesList.Contains("Cheese"))
+		{
+			namesList.Remove("Cheese");
+		}
+
+		//Turn it all back into one string and return it
+		return String.Join("\n", namesList.ToArray());
+	}
+}

--- a/Assets/scripts/ui/CreditsParser.cs.meta
+++ b/Assets/scripts/ui/CreditsParser.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 57bd2916956de439aa6e1fca4dc82e2c
+timeCreated: 1493087781
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scripts/ui/UGUIButtons.cs
+++ b/Assets/scripts/ui/UGUIButtons.cs
@@ -6,6 +6,7 @@ using UnityEngine.SceneManagement;
 public class UGUIButtons : MonoBehaviour {
     public GameObject optionsPanel;
     public GameObject creditsPanel;
+    public GameObject aboutPanel;
 
     void Awake()
     {
@@ -31,7 +32,7 @@ public class UGUIButtons : MonoBehaviour {
         {
             optionsPanel.SetActive(false);
         }
-    }
+	}
 
     public void CreditsButton()
     {
@@ -46,6 +47,19 @@ public class UGUIButtons : MonoBehaviour {
         }
     }
 
+    public void AboutButton()
+    {
+        if (aboutPanel.activeSelf == false)
+        {
+            CloseAllPanels();
+            aboutPanel.SetActive(true);
+        }
+        else if (aboutPanel.activeSelf == true)
+        {
+            aboutPanel.SetActive(false);
+        }
+    }
+
     public void QuitButton()
     {
         //this should probably open a menu confirming your selection
@@ -56,5 +70,6 @@ public class UGUIButtons : MonoBehaviour {
     {
         optionsPanel.SetActive(false);
         creditsPanel.SetActive(false);
+        aboutPanel.SetActive(false);
     }
 }


### PR DESCRIPTION
* Adds an auto scrolling view of the game credits based on merged versions of the three dependent credits files (needs details of third party code/licences).
* Adds an initial "about" panel indicating that the game was made by community members and where to find sources/forums (needs buttons for launching those locations in a web browser)