### PR TITLE
Changes for 2 player control

### DIFF
--- a/Assets/MainMenu.unity
+++ b/Assets/MainMenu.unity
@@ -5235,8 +5235,8 @@ MonoBehaviour:
   m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
+  m_HorizontalAxis: 1Horizontal
+  m_VerticalAxis: 1Vertical
   m_SubmitButton: Submit
   m_CancelButton: Cancel
   m_InputActionsPerSecond: 10

--- a/Assets/entities/shared/paddle_prefab.prefab
+++ b/Assets/entities/shared/paddle_prefab.prefab
@@ -160,22 +160,22 @@ MonoBehaviour:
   m_SceneId:
     m_Value: 0
   m_AssetId:
-    i0: 45
-    i1: 49
-    i2: 205
-    i3: 47
-    i4: 34
-    i5: 193
-    i6: 153
-    i7: 212
-    i8: 202
-    i9: 8
-    i10: 20
-    i11: 130
-    i12: 126
-    i13: 172
-    i14: 254
-    i15: 63
+    i0: 230
+    i1: 109
+    i2: 11
+    i3: 54
+    i4: 141
+    i5: 192
+    i6: 64
+    i7: 68
+    i8: 251
+    i9: 11
+    i10: 28
+    i11: 112
+    i12: 122
+    i13: 54
+    i14: 89
+    i15: 77
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 1
 --- !u!114 &114889014047957614
@@ -189,6 +189,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de954ce9e42c3f848bc2ba60cc5816b1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNum: 0
 --- !u!114 &114926957746133038
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -200,8 +201,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2275ac37e67904bc79427cc4f5875617, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  paddleClientId: 0
-  paddleIndex: 0
 --- !u!136 &136224915192230348
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/scripts/entity/Player.cs
+++ b/Assets/scripts/entity/Player.cs
@@ -8,10 +8,13 @@ using UnityEngine.Networking;
 /// </summary>
 
 public class Player : PaddleBase {
+    //use this in inspector on your prefab to assign player?  Will that work?  Idfk.  *crosses fingers* -sjm
+    public int playerNum = 1;
 
 	// Use this for initialization
 	public override void Start()
     {
+        playerNum = 1;
 		base.Start();
 		
 		// Give the player faster movement
@@ -22,12 +25,20 @@ public class Player : PaddleBase {
     {
         base.FixedUpdate();
 
-        float haxis = Input.GetAxis("Horizontal");
-        float vaxis = Input.GetAxis("Vertical");
+        //float haxis = Input.GetAxis("Horizontal");
+        //float vaxis = Input.GetAxis("Vertical");
+
+        //testing 2 player local
+        float haxis = Input.GetAxis(playerNum+"Horizontal");
+        float vaxis = Input.GetAxis(playerNum+"Vertical");
+        //float vaxis = Input.GetAxis("1Vertical");
+
+
+        //Local Multiplayer
 
         if (haxis != 0)
         {
-
+            
         }
 
         if (vaxis != 0)
@@ -36,7 +47,9 @@ public class Player : PaddleBase {
         }
 
         // If Fire1 is pressed, trigger pull animation
-        if (Input.GetButton("Fire1"))
+        //if (Input.GetButton("Fire1"))
+        if (Input.GetButton(playerNum+"Fire1"))
+
         {
             animator.SetBool("pull", true);
             animator.SetBool("hit", true);
@@ -51,7 +64,8 @@ public class Player : PaddleBase {
     private new void Update()
     {
         base.Update();
-        if (Input.GetKeyDown(KeyCode.Space) &&  (myPowers.Count > 0 || currentPowerName!=""))
+        //if (Input.GetKeyDown(KeyCode.Space) &&  (myPowers.Count > 0 || currentPowerName!=""))
+        if (Input.GetButton(playerNum+"Fire2") &&  (myPowers.Count > 0 || currentPowerName!=""))
         {
             TryActivate();
         }

--- a/Assets/scripts/entity/Player.cs
+++ b/Assets/scripts/entity/Player.cs
@@ -14,7 +14,7 @@ public class Player : PaddleBase {
 	// Use this for initialization
 	public override void Start()
     {
-        playerNum = 1;
+        //playerNum = 1;
 		base.Start();
 		
 		// Give the player faster movement

--- a/Assets/scripts/ui/BasicMenu.cs
+++ b/Assets/scripts/ui/BasicMenu.cs
@@ -229,6 +229,9 @@ public class BasicMenu : MonoBehaviour
                             }
 
                             paddleIndex++;
+
+                            //this should change one Player scripts playerNum to 1 and one to 2 in order to allow 2 players
+                            // Doesn't seem to be working. atm.
                             paddle.GetComponent<Player>().playerNum = paddleIndex;
                             Debug.Log("paddleIndex is "+ paddleIndex);
                         }

--- a/Assets/scripts/ui/BasicMenu.cs
+++ b/Assets/scripts/ui/BasicMenu.cs
@@ -219,6 +219,8 @@ public class BasicMenu : MonoBehaviour
                             var paddlePrefab = playerPrefabs[Mathf.Clamp(paddleIndex, 0, playerPrefabs.Length)];
                             GameObject paddle = GameObject.Instantiate(paddlePrefab, paddlePos);
 
+
+
                             // Spawn on the clients
                             if (NetworkManager.singleton.isNetworkActive)
                             {
@@ -227,6 +229,8 @@ public class BasicMenu : MonoBehaviour
                             }
 
                             paddleIndex++;
+                            paddle.GetComponent<Player>().playerNum = paddleIndex;
+                            Debug.Log("paddleIndex is "+ paddleIndex);
                         }
                     }
 

--- a/Assets/scripts/utils/GameControlButtonTest.cs
+++ b/Assets/scripts/utils/GameControlButtonTest.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameControlButtonTest : MonoBehaviour {
+    //This doesn't work very well.
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+        if(Input.anyKey)
+        {
+            Debug.Log(Input.inputString);
+        }
+      
+	}
+}

--- a/Assets/scripts/utils/GameControlButtonTest.cs.meta
+++ b/Assets/scripts/utils/GameControlButtonTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8cf5ebe37aed3408ab6c4bb4fbf31496
+timeCreated: 1493100530
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/tables/Table02.unity
+++ b/Assets/tables/Table02.unity
@@ -175,52 +175,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4332782387150468, guid: 77a3d8b8c9b676f408a4d89e5c0a0324,
     type: 2}
   m_PrefabInternal: {fileID: 10191937}
---- !u!1001 &10432600
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.002793863
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0.37
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0.56
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0.7063106
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.70790213
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1398745474243218, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_Name
-      value: Ball Spawner (2)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1001 &10766910
 Prefab:
   m_ObjectHideFlags: 0
@@ -357,7 +311,7 @@ MonoBehaviour:
   pressedPosition: 45
   flipperStrength: 2000
   flipperDamper: 5
-  inputButtonName: LeftFlipper
+  inputButtonName: 2LeftFlipper
 --- !u!59 &109119900
 HingeJoint:
   m_ObjectHideFlags: 0
@@ -562,7 +516,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 3.6935463}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &345536927
 Prefab:
@@ -1113,7 +1067,7 @@ MonoBehaviour:
   pressedPosition: -45
   flipperStrength: 2000
   flipperDamper: 5
-  inputButtonName: RightFlipper
+  inputButtonName: 2RightFlipper
 --- !u!114 &847371453
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1464,7 +1418,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4648527162676858, guid: 7a9b090a7cfbc28449aceef5937fc259, type: 2}
       propertyPath: m_RootOrder
-      value: 7
+      value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a9b090a7cfbc28449aceef5937fc259, type: 2}
@@ -1549,7 +1503,7 @@ Transform:
   m_LocalScale: {x: 1, y: 2.7525725, z: 2.8035629}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1189642327
 Prefab:
@@ -1588,7 +1542,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4917716161847422, guid: f74c2abcd38fd9e4aa07547d5be24b8e, type: 2}
       propertyPath: m_RootOrder
-      value: 6
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f74c2abcd38fd9e4aa07547d5be24b8e, type: 2}
@@ -1933,7 +1887,7 @@ MonoBehaviour:
   pressedPosition: 45
   flipperStrength: 2000
   flipperDamper: 5
-  inputButtonName: LeftFlipper
+  inputButtonName: 1LeftFlipper
 --- !u!114 &1515719041
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1982,7 +1936,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 400026, guid: 9aa4b3a2098814d2e845bb10b0d09749, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2300116, guid: 9aa4b3a2098814d2e845bb10b0d09749, type: 3}
       propertyPath: m_Enabled
@@ -2237,52 +2191,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4332782387150468, guid: 77a3d8b8c9b676f408a4d89e5c0a0324,
     type: 2}
   m_PrefabInternal: {fileID: 1620545580}
---- !u!1001 &1706873846
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.07
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0.33
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4653202098466440, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1398745474243218, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 9a829cba44a814e8d97da9ac5bfc0a66, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1 &1732647867
 GameObject:
   m_ObjectHideFlags: 0
@@ -2313,7 +2221,7 @@ Transform:
   - {fileID: 109119897}
   - {fileID: 847371448}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1763213701
 Prefab:
@@ -2416,7 +2324,7 @@ Transform:
   - {fileID: 1895793312}
   - {fileID: 760953225}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 89.871, z: 0}
 --- !u!1001 &1862793030
 Prefab:
@@ -2503,7 +2411,7 @@ MonoBehaviour:
   pressedPosition: -45
   flipperStrength: 2000
   flipperDamper: 5
-  inputButtonName: RightFlipper
+  inputButtonName: 1RightFlipper
 --- !u!59 &1862793034
 HingeJoint:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -36,6 +36,7 @@ GraphicsSettings:
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -74,9 +74,9 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left ctrl
+    positiveButton: space
     altNegativeButton: 
-    altPositiveButton: mouse 0
+    altPositiveButton: joystick 1 button 1
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -217,8 +217,8 @@ InputManager:
     m_Name: 2Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: w
-    positiveButton: s
+    negativeButton: y
+    positiveButton: h
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
@@ -233,8 +233,8 @@ InputManager:
     m_Name: 2Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: w
-    positiveButton: s
+    negativeButton: y
+    positiveButton: h
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
@@ -362,7 +362,7 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left alt
+    positiveButton: right ctrl
     altNegativeButton: 
     altPositiveButton: joystick 1 button 6
     gravity: 1000
@@ -378,7 +378,7 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: right alt
+    positiveButton: left alt
     altNegativeButton: 
     altPositiveButton: joystick 2 button 6
     gravity: 1000
@@ -396,7 +396,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick 1 button 7
     altNegativeButton: 
-    altPositiveButton: left ctrl
+    altPositiveButton: right ctrl
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -412,7 +412,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick 2 button 7
     altNegativeButton: 
-    altPositiveButton: right ctrl
+    altPositiveButton: left ctrl
     gravity: 1000
     dead: 0.001
     sensitivity: 1000

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -9,34 +9,66 @@ InputManager:
     m_Name: 1Horizontal
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: a
-    positiveButton: d
+    negativeButton: left
+    positiveButton: right
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
-    snap: 1
+    snap: 0
     invert: 0
     type: 0
+    axis: 0
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: 1Horizontal
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: left
+    positiveButton: right
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
     axis: 0
     joyNum: 1
   - serializedVersion: 3
     m_Name: 1Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: s
-    positiveButton: w
+    negativeButton: up
+    positiveButton: down
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
-    snap: 1
-    invert: 0
+    snap: 0
+    invert: 1
     type: 0
     axis: 1
-    joyNum: 2
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: 1Vertical
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: up
+    positiveButton: down
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 1
+    type: 2
+    axis: 1
+    joyNum: 1
   - serializedVersion: 3
     m_Name: 1Fire1
     descriptiveName: 
@@ -153,8 +185,24 @@ InputManager:
     m_Name: 2Horizontal
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: left
-    positiveButton: right
+    negativeButton: a
+    positiveButton: d
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: 2Horizontal
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: a
+    positiveButton: d
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
@@ -169,8 +217,24 @@ InputManager:
     m_Name: 2Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: up
-    positiveButton: down
+    negativeButton: w
+    positiveButton: s
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 1
+    type: 0
+    axis: 1
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: 2Vertical
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: w
+    positiveButton: s
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
@@ -314,7 +378,7 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: 
+    positiveButton: right alt
     altNegativeButton: 
     altPositiveButton: joystick 2 button 6
     gravity: 1000
@@ -330,9 +394,9 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left ctrl
+    positiveButton: joystick 1 button 7
     altNegativeButton: 
-    altPositiveButton: joystick 1 button 5
+    altPositiveButton: left ctrl
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -346,9 +410,9 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: 
+    positiveButton: joystick 2 button 7
     altNegativeButton: 
-    altPositiveButton: joystick 2 button 5
+    altPositiveButton: right ctrl
     gravity: 1000
     dead: 0.001
     sensitivity: 1000

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -6,13 +6,13 @@ InputManager:
   serializedVersion: 2
   m_Axes:
   - serializedVersion: 3
-    m_Name: Horizontal
+    m_Name: 1Horizontal
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: left
-    positiveButton: right
-    altNegativeButton: a
-    altPositiveButton: d
+    negativeButton: a
+    positiveButton: d
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
@@ -20,25 +20,25 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 1
   - serializedVersion: 3
-    m_Name: Vertical
+    m_Name: 1Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: down
-    positiveButton: up
-    altNegativeButton: s
-    altPositiveButton: w
+    negativeButton: s
+    positiveButton: w
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
     snap: 1
     invert: 0
     type: 0
-    axis: 0
-    joyNum: 0
+    axis: 1
+    joyNum: 2
   - serializedVersion: 3
-    m_Name: Fire1
+    m_Name: 1Fire1
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
@@ -52,9 +52,9 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 1
   - serializedVersion: 3
-    m_Name: Fire2
+    m_Name: 1Fire2
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
@@ -68,7 +68,7 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 1
   - serializedVersion: 3
     m_Name: Fire3
     descriptiveName: 
@@ -84,7 +84,7 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 1
   - serializedVersion: 3
     m_Name: Jump
     descriptiveName: 
@@ -150,11 +150,11 @@ InputManager:
     axis: 2
     joyNum: 0
   - serializedVersion: 3
-    m_Name: Horizontal
+    m_Name: 2Horizontal
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: 
+    negativeButton: left
+    positiveButton: right
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
@@ -164,13 +164,13 @@ InputManager:
     invert: 0
     type: 2
     axis: 0
-    joyNum: 0
+    joyNum: 2
   - serializedVersion: 3
-    m_Name: Vertical
+    m_Name: 2Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: 
+    negativeButton: up
+    positiveButton: down
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
@@ -180,13 +180,13 @@ InputManager:
     invert: 1
     type: 2
     axis: 1
-    joyNum: 0
+    joyNum: 2
   - serializedVersion: 3
-    m_Name: Fire1
+    m_Name: 2Fire1
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: joystick button 0
+    positiveButton: joystick 2 button 1
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1000
@@ -196,13 +196,13 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 2
   - serializedVersion: 3
-    m_Name: Fire2
+    m_Name: 2Fire2
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: joystick button 1
+    positiveButton: joystick 2 button 2
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1000
@@ -212,13 +212,13 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 2
   - serializedVersion: 3
     m_Name: Fire3
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: joystick button 2
+    positiveButton: joystick 2 button 3
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1000
@@ -228,7 +228,7 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 2
   - serializedVersion: 3
     m_Name: Jump
     descriptiveName: 
@@ -294,13 +294,13 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
-    m_Name: RightFlipper
+    m_Name: 1RightFlipper
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: left alt
     altNegativeButton: 
-    altPositiveButton: joystick button 1
+    altPositiveButton: joystick 1 button 6
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -308,15 +308,31 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 1
   - serializedVersion: 3
-    m_Name: LeftFlipper
+    m_Name: 2RightFlipper
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: joystick 2 button 6
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: 1LeftFlipper
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: left ctrl
     altNegativeButton: 
-    altPositiveButton: joystick button 2
+    altPositiveButton: joystick 1 button 5
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -324,4 +340,20 @@ InputManager:
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: 2LeftFlipper
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: joystick 2 button 5
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 2


### PR DESCRIPTION
This should add 2 player support for both controllers and incomplete keyboard controls
for two players, both paddles will need to be selected for this to work

on keyboard
left player is w and s.  right is up and down

on joystick
left and right buttons should control your side of the flippers
up and down on either left analog or direction pad should work(may differ depending on player. need to fix that)

The change to main menu scene can be quickly redone.  Toss them if need be.  They're important but super easy.

Unfortunately a lot of this I wasn't able to test because unity stopped responding to my controllers for no reason.