### PR TITLE
Quick fix to power spawning

### DIFF
--- a/Assets/entities/paddle/paddle-kednar2/paddle_k2_p1.prefab
+++ b/Assets/entities/paddle/paddle-kednar2/paddle_k2_p1.prefab
@@ -163,7 +163,6 @@ GameObject:
   - component: {fileID: 114995829780925928}
   - component: {fileID: 114245300654168584}
   - component: {fileID: 65366183662971692}
-  - component: {fileID: 114342854358842022}
   m_Layer: 0
   m_Name: paddle_k2_p1
   m_TagString: Untagged
@@ -728,17 +727,6 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: de954ce9e42c3f848bc2ba60cc5816b1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114342854358842022
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1512352645870626}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b42a04b731786ed4d8dc2c19c80c94ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &114499133632231710

--- a/Assets/entities/paddle/paddle-kednar2/paddle_k2_p2.prefab
+++ b/Assets/entities/paddle/paddle-kednar2/paddle_k2_p2.prefab
@@ -75,7 +75,6 @@ GameObject:
   - component: {fileID: 114649665207994020}
   - component: {fileID: 114479235123591318}
   - component: {fileID: 65616643357437704}
-  - component: {fileID: 114843082368988466}
   m_Layer: 0
   m_Name: paddle_k2_p2
   m_TagString: Untagged
@@ -761,17 +760,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6da8aa0754d1c894dae87a6972e0f56b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114843082368988466
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1137339957486028}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b42a04b731786ed4d8dc2c19c80c94ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &114987137566065340

--- a/Assets/entities/paddle/paddle-kednar2/paddle_k2_p3.prefab
+++ b/Assets/entities/paddle/paddle-kednar2/paddle_k2_p3.prefab
@@ -43,7 +43,6 @@ GameObject:
   - component: {fileID: 114140835183574380}
   - component: {fileID: 114278296881885654}
   - component: {fileID: 65679834368048412}
-  - component: {fileID: 114352672700694652}
   m_Layer: 0
   m_Name: paddle_k2_p3
   m_TagString: Untagged
@@ -773,17 +772,6 @@ MonoBehaviour:
     i15: 234
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 1
---- !u!114 &114352672700694652
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1054660396546120}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b42a04b731786ed4d8dc2c19c80c94ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114913661327812620
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/entities/paddle/paddle-kednar2/paddle_k2_p4.prefab
+++ b/Assets/entities/paddle/paddle-kednar2/paddle_k2_p4.prefab
@@ -135,7 +135,6 @@ GameObject:
   - component: {fileID: 114952372630654812}
   - component: {fileID: 114220172038397076}
   - component: {fileID: 65442794501474928}
-  - component: {fileID: 114460000884382458}
   m_Layer: 0
   m_Name: paddle_k2_p4
   m_TagString: Untagged
@@ -762,17 +761,6 @@ MonoBehaviour:
     i15: 226
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 1
---- !u!114 &114460000884382458
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1401081363770172}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b42a04b731786ed4d8dc2c19c80c94ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114666278001560324
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/scripts/ui/BasicMenu.cs
+++ b/Assets/scripts/ui/BasicMenu.cs
@@ -224,6 +224,10 @@ public class BasicMenu : MonoBehaviour
                             int paddleIndex = Mathf.FloorToInt(Random.Range(0, playerPrefabs.Length) );
                             var paddlePrefab = playerPrefabs[paddleIndex];
                             GameObject paddle = GameObject.Instantiate(paddlePrefab, paddlePos);
+                            if(playerIndex==0)
+                            {
+                                paddle.AddComponent<PowerManager>();
+                            }
 
                             // Spawn on the clients
                             if (NetworkManager.singleton.isNetworkActive)
@@ -232,7 +236,7 @@ public class BasicMenu : MonoBehaviour
                                 paddle.GetComponent<PaddleNetworking>().SetPaddleIndex(playerIndex);
                             }
 
-                            playerIndex++;
+                            ++playerIndex;
                         }
                     }
 


### PR DESCRIPTION
Creating random paddle types for each player revealed an issue with having multiple PowerManagers.  Removed PowerManager from the prefabs and added in code.