### PR TITLE
momentum stopper

### DIFF
--- a/Assets/scripts/entity/PaddleBase.cs
+++ b/Assets/scripts/entity/PaddleBase.cs
@@ -47,6 +47,12 @@ public class PaddleBase : NetworkBehaviour {
 
 		if (rigidBody)
         {
+
+            //Stop momentum caused by switching controllers
+            Vector3 zero = new Vector3(0, 0, 0);
+            rigidBody.velocity = zero;
+            rigidBody.angularVelocity = zero;
+
             // Invert for one side
             if (transform.position.x < 0) dir *= -1;
 


### PR DESCRIPTION
#96 
Objects were keeping momentum on the server when paddle controllers were switched AI -> player.

(Taking control, waiting ~2mins without hitting anything still takes the paddle OOB)