### PR TITLE
Bindings fixes

### DIFF
--- a/Assets/scripts/LoadAssets.cs
+++ b/Assets/scripts/LoadAssets.cs
@@ -9,28 +9,28 @@ public class LoadAssets : MonoBehaviour {
 
     // TODO: Can we display dictionaries in the editor??
     public Dictionary<string, bool> variantNames = new Dictionary<string, bool>() {
-        { "lightsoda", false },
-        { "kgunn", false },
-	{ "kednar", false }
-  	};
-    public Dictionary<string, bool> tableNames = new Dictionary<string, bool>() {
-        { "Empty", false },
-        { "Bumpout", false },
-        { "Flippers", false },
-        { "Speedster", false },
-        { "Table_kednar", false }
+		{ "lightsoda", false },
+		{ "kgunn", false },
+		{ "kednar", false }
+	};
+	public Dictionary<string, bool> tableNames = new Dictionary<string, bool>() {
+		{ "Empty", false },
+		{ "Bumpout", false },
+		{ "Flippers", false },
+		{ "Speedster", false },
+		{ "Table_kednar", false }
 	};
 	public Dictionary<string, bool> paddleNames = new Dictionary<string, bool>() {
-		    { "tron", false },
-		    { "robot blue", false },
-        { "robot green", false },
-        { "robot red", false },
-        { "robot yellow", false }
-  };
+		{ "tron", false },
+		{ "robot blue", false },
+		{ "robot green", false },
+		{ "robot red", false },
+		{ "robot yellow", false }
+	};
 
 	public GameObject[] playerPrefabs;
 
-    private string[] activeVariants;
+	private string[] activeVariants;
 	private bool finishedLoading;
 
 	public bool bundlesLoaded;

--- a/Assets/scripts/ui/GameMenuHandlerUGUI.cs
+++ b/Assets/scripts/ui/GameMenuHandlerUGUI.cs
@@ -116,10 +116,10 @@ public class GameMenuHandlerUGUI : MonoBehaviour {
         }
 
         instruction.text += "CONTROLS:\n";
-        instruction.text += "Y = move up\n";
-        instruction.text += "H = move down\n";
-        instruction.text += "Z = activate power\n";
-        instruction.text += "Q = hit animation (currently no effect on gameplay)\n\n";
+        instruction.text += "W or E = move up\n";
+        instruction.text += "S = move down\n";
+        instruction.text += "Left Shift = activate power\n";
+        instruction.text += "Left Ctrl = hit animation (currently no effect on gameplay) and flippers\n\n";
 
         // If multiplayer selected (online or offline): 
         if (!singlePlayerSelected)
@@ -127,8 +127,8 @@ public class GameMenuHandlerUGUI : MonoBehaviour {
             instruction.text += "RIGHT PLAYER CONTROLS:\n";
             instruction.text += "Up = move up\n";
             instruction.text += "Down = move down\n";
-            instruction.text += "Left Alt = activate power\n";
-            instruction.text += "Space = hit animation (currently no effect on gameplay)\n\n";
+            instruction.text += "Right Shift = activate power\n";
+            instruction.text += "Right Ctrl = hit animation (currently no effect on gameplay) and flippers\n\n";
         }
     }
 

--- a/Assets/scripts/ui/GameSelectionMenuUGUI.cs
+++ b/Assets/scripts/ui/GameSelectionMenuUGUI.cs
@@ -50,13 +50,13 @@ public class GameSelectionMenuUGUI : MonoBehaviour {
     public void BackButton(string selectionType)
     {
         indexLength = loadAssets.GetCount(selectionType) - 1;
-        if (currentIndex[selectionType] < indexLength)
+        if (currentIndex[selectionType] > 0)
         {
-            currentIndex[selectionType] = indexLength;
+            currentIndex[selectionType]--;
         }
         else
         {
-            currentIndex[selectionType]--;
+            currentIndex[selectionType] = indexLength;
         }
         SetSelectionText(selectionType, loadAssets.GetName(selectionType, currentIndex[selectionType]));
     }

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -74,7 +74,7 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: space
+    positiveButton: right ctrl
     altNegativeButton: 
     altPositiveButton: joystick 1 button 1
     gravity: 1000
@@ -90,9 +90,9 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left alt
+    positiveButton: right shift
     altNegativeButton: 
-    altPositiveButton: mouse 1
+    altPositiveButton: joystick 1 button 2
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -217,9 +217,9 @@ InputManager:
     m_Name: 2Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: y
-    positiveButton: h
-    altNegativeButton: 
+    negativeButton: w
+    positiveButton: s
+    altNegativeButton: e
     altPositiveButton: 
     gravity: 3
     dead: 0.001
@@ -233,9 +233,9 @@ InputManager:
     m_Name: 2Vertical
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: y
-    positiveButton: h
-    altNegativeButton: 
+    negativeButton: w
+    positiveButton: s
+    altNegativeButton: e
     altPositiveButton: 
     gravity: 0
     dead: 0.19
@@ -252,7 +252,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick 2 button 1
     altNegativeButton: 
-    altPositiveButton: q
+    altPositiveButton: left ctrl
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -268,7 +268,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick 2 button 2
     altNegativeButton: 
-    altPositiveButton: z
+    altPositiveButton: left shift
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -364,7 +364,7 @@ InputManager:
     negativeButton: 
     positiveButton: right ctrl
     altNegativeButton: 
-    altPositiveButton: joystick 1 button 6
+    altPositiveButton: joystick 1 button 4
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -378,9 +378,9 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left alt
+    positiveButton: left ctrl
     altNegativeButton: 
-    altPositiveButton: joystick 2 button 6
+    altPositiveButton: joystick 2 button 4
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -394,7 +394,7 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: joystick 1 button 7
+    positiveButton: joystick 1 button 5
     altNegativeButton: 
     altPositiveButton: right ctrl
     gravity: 1000
@@ -410,7 +410,7 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: joystick 2 button 7
+    positiveButton: joystick 2 button 5
     altNegativeButton: 
     altPositiveButton: left ctrl
     gravity: 1000


### PR DESCRIPTION
This pull request supersedes #122. I had to make some executive decisions and compromises, but I hope I've come up with something that addresses most people's concerns.

Firstly, left player directional input has been moved to W and S, with E serving as an alternate up button (note that all our keybindings are probably nonsense on DVORAK or AZERTY keyboards - I've got some fixes for that, but I'll bring those in later) that is comfortable when using a keyboard at an extreme angle.

Secondly, keyboard controls use one key for the pull/hit and both flippers. With flippers being so small a part of the game right now, the benefit of a simple control scheme outweighs the fun of controlling flippers separately IMO.

Thirdly, Ctrl and Shift have been selected to give both left and right players symmetrical bindings (having left players use space and right players use enter means changing hand layouts when changing sides and that feels worth avoiding right now).

Finally, there were several bugs in the gamepad bindings (buttons configured as axes, bumper button indexes being off, etc.). The changes here address those and are not related to platform specific gamepad concerns (haven't tested Mac bindings, but Linux stuff seems OK on my Logitech F310).

Below is a summary of current controls:

**Right player  (player 2):**
* Keyboard
  * Up		- up
  * Down		- down
  * Right Ctrl	- pull/hit and flippers
  * Right Shift	- power

* Joystick 2 (360 controller)
  * Left analog	- up / down
  * B			- pull/hit
  * X			- power
  * Left bumper	- left flipper
  * Right bumper- right flipper

**Left player (player 1):**
* Keyboard
  * W or E		- up
  * S			- down
  * Left Ctrl	- pull/hit and flippers
  * Left Shift	- power

* Joystick 1 (360 controller)
  * Left analog	- up / down
  * B			- pull/hit
  * X			- power
  * Left bumper	- left flipper
  * Right bumper- right flipper
