### PR TITLE
Changed opacity of menu background map

### DIFF
--- a/Assets/MainMenu.unity
+++ b/Assets/MainMenu.unity
@@ -401,7 +401,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.8}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -485,6 +485,7 @@ MonoBehaviour:
   - {fileID: 2090694357}
   - {fileID: 658595074}
   - {fileID: 1924510281}
+  timer: 0
 --- !u!114 &232932570
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
To take the edge off of the background and so that the white text is more readable over the entire screen, like in the credits