### PR TITLE
Paddle control tuning

### DIFF
--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -45,7 +45,7 @@ InputManager:
     positiveButton: down
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 3
+    gravity: 10
     dead: 0.001
     sensitivity: 3
     snap: 0
@@ -63,7 +63,7 @@ InputManager:
     altPositiveButton: 
     gravity: 0
     dead: 0.19
-    sensitivity: 1
+    sensitivity: 0.8
     snap: 0
     invert: 1
     type: 2
@@ -221,7 +221,7 @@ InputManager:
     positiveButton: s
     altNegativeButton: e
     altPositiveButton: 
-    gravity: 3
+    gravity: 10
     dead: 0.001
     sensitivity: 3
     snap: 0
@@ -239,7 +239,7 @@ InputManager:
     altPositiveButton: 
     gravity: 0
     dead: 0.19
-    sensitivity: 1
+    sensitivity: 0.8
     snap: 0
     invert: 1
     type: 2


### PR DESCRIPTION
#139 
Controller paddle speed slowed 20%
keyboard paddle speed falloff increased 300%+

Controls aren't the same because of how they physically are.  Keys have acceleration so they can make slight moves but also reach far, and stop quickly.  Gamepad paddle speed is tied to the thumb-stick tilt.
