### PR TITLE
fix client not being assigned a paddle

### DIFF
--- a/Assets/scripts/LoadAssets.cs
+++ b/Assets/scripts/LoadAssets.cs
@@ -360,7 +360,7 @@ public class LoadAssets : MonoBehaviour {
 			foreach (Transform spawnPosition in NetworkManager.singleton.startPositions)
 			{
 				Transform paddlePos = spawnPosition;
-				int paddleIndex = Mathf.FloorToInt(Random.Range(0, playerPrefabs.Length) );
+				//int paddleIndex = Mathf.FloorToInt(Random.Range(0, playerPrefabs.Length) );
 				var paddlePrefab = playerPrefabs[GetIndexAtDictionaryKey(GetActiveFromDictionary(paddleNames), paddleNames)];
 				GameObject paddle = GameObject.Instantiate(paddlePrefab, paddlePos);
 				if(playerIndex==0)
@@ -372,7 +372,7 @@ public class LoadAssets : MonoBehaviour {
 				if (NetworkManager.singleton.isNetworkActive)
 				{
 					NetworkServer.Spawn(paddle);
-					paddle.GetComponent<PaddleNetworking>().SetPaddleIndex(paddleIndex);
+					paddle.GetComponent<PaddleNetworking>().SetPaddleIndex(playerIndex);
 				}
 
 				playerIndex++;
@@ -380,7 +380,7 @@ public class LoadAssets : MonoBehaviour {
 				//this should change one Player scripts playerNum to 1 and one to 2 in order to allow 2 players
 				// Doesn't seem to be working. atm.
 				paddle.GetComponent<Player>().playerNum = playerIndex;
-				Debug.Log("paddleIndex is "+ paddleIndex);
+				//Debug.Log("paddleIndex is "+ paddleIndex);
 			}
 		}
 


### PR DESCRIPTION
int paddleIndex = Mathf.FloorToInt(Random.Range(0, playerPrefabs.Length) );
Was created to give a random paddle colour but was being used as networkID.  If server and client had the same random paddleIndex, server would be assigned both paddles and client would get none.
#123 